### PR TITLE
Support node-webkit and fixed bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -482,12 +482,13 @@
 			if ( typeof str !== 'string')
 				return str;
 
-			return str.replace(/[\+ \|\^]/g, function(a) {
+			return str.replace(/[\+ \|\^\%]/g, function(a) {
 				return ({
 				' ' : '+',
 				'+' : '%2B',
 				'|' : '%7C',
-				'^' : '%5E'
+				'^' : '%5E',
+				'%' : '%25'
 				})[a]
 			});
 		};
@@ -496,12 +497,13 @@
 			if ( typeof str !== 'string')
 				return str;
 
-			return str.replace(/\+|%2B|%7C|%5E/g, function(a) {
+			return str.replace(/\+|%2B|%7C|%5E|%25/g, function(a) {
 				return ({
 				'+' : ' ',
 				'%2B' : '+',
 				'%7C' : '|',
-				'%5E' : '^'
+				'%5E' : '^',
+				'%25' : '%'
 				})[a]
 			})
 		};


### PR DESCRIPTION
In node-webkit, both window and exports exist, but exports should be used instead of window.

Also fixed two escaping bugs:
1. `^` is not escaped so `unpack( pack( { x: '^' } ) )` gives error
2. `%` is not escaped so `unpack( pack( { x: '%7C' } ) )` gives { x : '|' }
