### PR TITLE
Add charAt when looping through string for IE8

### DIFF
--- a/main.js
+++ b/main.js
@@ -317,7 +317,8 @@
 			// Tokenizer the structure
 			var number36 = '';
 			var tokens = [];
-			for (var i = 0, len = rawBuffers[3].length; i < len; i++) {
+			var len=rawBuffers[3].length;
+			for (var i = 0; i < len; i++) {
 				var symbol = rawBuffers[3].charAt(i);
 				if (symbol === '|' || symbol === '$' || symbol === '@' || symbol === ']') {
 					if (number36) {


### PR DESCRIPTION
We're using this plugin to shorten our urls on IE8. It's working really well, but we noticed that it can't handle looping over a string without an explicit "charAt."

I put it in and it's fixing the problem.
