### PR TITLE
Use a regular for loop instead of for-in when unpacking the buffer

### DIFF
--- a/main.js
+++ b/main.js
@@ -285,7 +285,7 @@
 			if (buffer !== '') {
 				buffer = buffer.split('|');
 				options.verbose && console.log('Parse the strings dictionary');
-				for (var i in buffer) {
+				for (var i=0, n=buffer.length; i<n; i++){
 					dictionary.push(_decode(buffer[i]));
 				}
 			}
@@ -295,7 +295,7 @@
 			if (buffer !== '') {
 				buffer = buffer.split('|');
 				options.verbose && console.log('Parse the integers dictionary');
-				for (var i in buffer) {
+				for (var i=0, n=buffer.length; i<n; i++){
 					dictionary.push(_base36To10(buffer[i]));
 				}
 			}
@@ -305,7 +305,7 @@
 			if (buffer !== '') {
 				buffer = buffer.split('|')
 				options.verbose && console.log('Parse the floats dictionary');
-				for (var i in buffer) {
+				for (var i=0, n=buffer.length; i<n; i++){
 					dictionary.push(parseFloat(buffer[i]));
 				}
 			}


### PR DESCRIPTION
for...in looks at the array as an object, and therefore properties like "indexOf" or "length" may be included in the loo resulting in an error decoding the state.

This issue particularly impacts IE, see http://stackoverflow.com/questions/3705383/ie8-bug-in-for-in-javascript-statement