### PR TITLE
Avoid deleting a local variable.

### DIFF
--- a/main.js
+++ b/main.js
@@ -310,7 +310,7 @@
 				}
 			}
 			// Free memory
-			delete buffer;
+			buffer = null;
 
 			options.verbose && console.log('Tokenizing the structure');
 


### PR DESCRIPTION
The [`delete`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete) operator in JavaScript removes a property from an object, it has no effect on local variables or function names.

Even more important is the fact that deleting a local variable in [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) will cause an error.