### PR TITLE
Fix string with escape characters using existing string with escaped characters

### DIFF
--- a/main.js
+++ b/main.js
@@ -112,11 +112,12 @@
 				if (type === 'string') {
 
 					// The index of that word in the dictionary
-					var index = _indexOf.call(dictionary.strings, item);
+          				var encodedItem = _encode(item);
+					var index = _indexOf.call(dictionary.strings, encodedItem);
 
 					// If not, add to the dictionary and actualize the index
 					if (index == -1) {
-						dictionary.strings.push(_encode(item));
+						dictionary.strings.push(encodedItem);
 						index = dictionary.strings.length - 1;
 					}
 

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,12 @@ describe('jsonpack', function() {
         },
         deepObjectPacked = "attr1|string|hello|integer|float|true|false|null|attr2|attr3^1J9|1J9|1J9|1J9^1.2^$0|$1|2|3|A|4|E|5|-1|6|-2|7|-3]|8|$1|2|3|B|4|E|5|-1|6|-2|7|-3]|9|@$1|2|3|C|4|E|5|-1|6|-2|7|-3]|$1|2|3|D|4|E|5|-1|6|-2|7|-3]]]";
 
+    var escapedCharacterObject = {
+            attr1: " ",
+            attr2: "+",
+          },
+          escapedCharacterObjectPacked = "attr1|+|attr2|%2B^^^$0|1|2|3]";
+
     var arrayObject = [
             plainObject,
             deepObject
@@ -69,6 +75,10 @@ describe('jsonpack', function() {
 
         it('deep object', function() {
             expect(jsonpack.pack(deepObject)).to.eql(deepObjectPacked);
+        });
+
+        it('escaped string object', function() {
+          expect(jsonpack.pack(escapedCharacterObject)).to.eql(escapedCharacterObjectPacked);
         });
 
         it('complex array object', function() {


### PR DESCRIPTION
After packing a string containing an escaped character, a subsequent string containing the escape character would erroneously use the string with the escaped character. I've included a test that demonstrates this behavior.

This PR updates the string re-use check to escape the string before checking for a matching string in the dictionary.